### PR TITLE
feat: show summary of past 7 days instead of current week

### DIFF
--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/timeSpanSummary/TimeSpanSummaryFactory.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/timeSpanSummary/TimeSpanSummaryFactory.kt
@@ -1,16 +1,16 @@
 /*
- * Copyright (c) 2023 Joachim Ansorg.
+ * Copyright (c) 2023-2024 Joachim Ansorg.
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-package dev.ja.marketplace.data.week
+package dev.ja.marketplace.data.timeSpanSummary
 
 import dev.ja.marketplace.client.MarketplaceClient
 import dev.ja.marketplace.data.MarketplaceDataSink
 import dev.ja.marketplace.data.MarketplaceDataSinkFactory
 
-class WeekFactory : MarketplaceDataSinkFactory {
+class TimeSpanSummaryFactory(private val maxDays: Int, private val title: String) : MarketplaceDataSinkFactory {
     override fun createTableSink(client: MarketplaceClient, maxTableRows: Int?): MarketplaceDataSink {
-        return WeekTable()
+        return TimeSpanSummaryTable(maxDays, title)
     }
 }

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/timeSpanSummary/TimeSpanSummaryTable.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/timeSpanSummary/TimeSpanSummaryTable.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-package dev.ja.marketplace.data.week
+package dev.ja.marketplace.data.timeSpanSummary
 
 import dev.ja.marketplace.client.*
 import dev.ja.marketplace.client.Currency
@@ -11,7 +11,7 @@ import dev.ja.marketplace.data.*
 import java.math.BigDecimal
 import java.util.*
 
-class WeekTable(title: String = "This week") : SimpleDataTable(title, cssClass = "small table-striped"),
+class TimeSpanSummaryTable(maxDays: Int, title: String) : SimpleDataTable(title, cssClass = "small table-striped"),
     MarketplaceDataSink {
 
     private data class WeekData(
@@ -25,7 +25,7 @@ class WeekTable(title: String = "This week") : SimpleDataTable(title, cssClass =
     private val columnDownloads = DataTableColumn("total", "↓", "num", tooltip = "Downloads")
     private val columnTrials = DataTableColumn("total", "Trials", "num")
 
-    private val dateRange = YearMonthDayRange.currentWeek()
+    private val dateRange = YearMonthDay.now().let { YearMonthDayRange(it.add(0, 0, -maxDays), it) }
     private val data = TreeMap<YearMonthDay, WeekData>()
 
     override val columns: List<DataTableColumn> = listOf(columnDay, columnSales, columnDownloads, columnTrials)

--- a/src/main/kotlin/dev/ja/marketplace/MarketplaceStatsServer.kt
+++ b/src/main/kotlin/dev/ja/marketplace/MarketplaceStatsServer.kt
@@ -26,7 +26,7 @@ import dev.ja.marketplace.data.topCountries.TopCountriesFactory
 import dev.ja.marketplace.data.topTrialCountries.TopTrialCountriesFactory
 import dev.ja.marketplace.data.trials.TrialsTable
 import dev.ja.marketplace.data.trials.TrialsTableFactory
-import dev.ja.marketplace.data.week.WeekFactory
+import dev.ja.marketplace.data.timeSpanSummary.TimeSpanSummaryFactory
 import dev.ja.marketplace.data.yearSummary.YearlySummaryFactory
 import gg.jte.ContentType
 import gg.jte.TemplateEngine
@@ -66,7 +66,7 @@ class MarketplaceStatsServer(
         client,
         listOf(
             YearlySummaryFactory(),
-            WeekFactory(),
+            TimeSpanSummaryFactory(7, "Past 7 days"),
             DaySummaryFactory(0, "Today"),
             DaySummaryFactory(-1, "Yesterday"),
             CustomerTypeFactory(),


### PR DESCRIPTION
Showing 6 empty days at the beginning of a new week isn't helpful.