### PR TITLE
feat: experimental values for MRR and ARR. Likely to change.

### DIFF
--- a/marketplace-client/src/main/kotlin/dev/ja/marketplace/client/YearMonthDay.kt
+++ b/marketplace-client/src/main/kotlin/dev/ja/marketplace/client/YearMonthDay.kt
@@ -65,6 +65,10 @@ data class YearMonthDay(
         return instant.daysUntil(date.instant, timezone)
     }
 
+    fun monthsUntil(date: YearMonthDay): Int {
+        return instant.monthsUntil(date.instant, timezone)
+    }
+
     companion object {
         val MIN = YearMonthDay(1, 1, 1)
         val MAX = YearMonthDay(9999, 12, 31)
@@ -156,11 +160,22 @@ data class YearMonthDayRange(
         return YearMonthDayRange(start.add(years, months, days), end.add(years, months, days))
     }
 
+    fun expandStart(years: Int, months: Int, days: Int): YearMonthDayRange {
+        if (years == 0 && months == 0 && days == 0) {
+            return this
+        }
+        return YearMonthDayRange(start.add(years, months, days), end)
+    }
+
     fun expandEnd(years: Int, months: Int, days: Int): YearMonthDayRange {
         if (years == 0 && months == 0 && days == 0) {
             return this
         }
         return YearMonthDayRange(start, end.add(years, months, days))
+    }
+
+    fun countDays(): Int {
+        return start.daysUntil(end) + 1
     }
 
     private fun asIsoStringRange(): String {

--- a/marketplace-client/src/main/kotlin/dev/ja/marketplace/client/types.kt
+++ b/marketplace-client/src/main/kotlin/dev/ja/marketplace/client/types.kt
@@ -491,7 +491,12 @@ data class PluginSaleItemDiscount(
     val description: String,
     @SerialName("percent")
     val percent: Double? = null,
-)
+) {
+    val isContinuityDiscount: Boolean
+        get() {
+            return description.contains(" continuity discount")
+        }
+}
 
 @Serializable
 data class PluginTrial(
@@ -552,7 +557,19 @@ data class MarketplacePluginInfo(
     // only available with fullInfo=true
     @SerialName("versions")
     val majorVersions: List<PluginMajorVersion>? = null,
-)
+) {
+    fun subscriptionPrice(customerType: CustomerType, subscriptionType: LicensePeriod): Amount {
+        val basePrice = when (customerType) {
+            CustomerType.Organization -> this.businessPrice
+            CustomerType.Personal -> this.individualPrice
+        }
+        val factor = when (subscriptionType) {
+            LicensePeriod.Annual -> 10.0
+            LicensePeriod.Monthly -> 1.0
+        }
+        return basePrice * factor.toBigDecimal()
+    }
+}
 
 enum class DownloadCountType(val requestPathSegment: String) {
     Downloads("downloads-count"),

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/LicenseInfo.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/LicenseInfo.kt
@@ -30,7 +30,12 @@ data class LicenseInfo(
     val saleLineItem: PluginSaleItem,
 ) : WithDateRange, WithAmounts, Comparable<LicenseInfo> {
 
-    val isRenewal: Boolean
+    val isNewLicense: Boolean
+        get() {
+            return saleLineItem.type == PluginSaleItemType.New
+        }
+
+    val isRenewalLicense: Boolean
         get() {
             return saleLineItem.type == PluginSaleItemType.Renew
         }

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/PluginData.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/PluginData.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Joachim Ansorg.
+ * Copyright (c) 2023-2024 Joachim Ansorg.
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
@@ -11,6 +11,7 @@ data class PluginData(
     val pluginId: PluginId,
     val pluginSummary: PluginInfoSummary,
     val pluginInfo: PluginInfo,
+    val marketplacePluginInfo: MarketplacePluginInfo,
     val pluginRating: PluginRating,
     val totalDownloads: Long,
     val downloadsMonthly: List<MonthlyDownload>,

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/funnel/FunnelTable.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/funnel/FunnelTable.kt
@@ -8,8 +8,8 @@ package dev.ja.marketplace.data.funnel
 import dev.ja.marketplace.client.PluginId
 import dev.ja.marketplace.client.PluginSale
 import dev.ja.marketplace.data.*
-import dev.ja.marketplace.data.util.SimpleTrialTracker
-import dev.ja.marketplace.data.util.TrialTracker
+import dev.ja.marketplace.data.trackers.SimpleTrialTracker
+import dev.ja.marketplace.data.trackers.TrialTracker
 import kotlin.math.absoluteValue
 
 class FunnelTable : SimpleDataTable("Trial Funnel", "funnel", "table-centered sortable"), MarketplaceDataSink {

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/overview/OverviewTable.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/overview/OverviewTable.kt
@@ -12,12 +12,11 @@ import dev.ja.marketplace.client.Currency
 import dev.ja.marketplace.client.LicenseId
 import dev.ja.marketplace.data.*
 import dev.ja.marketplace.data.overview.OverviewTable.CustomerSegment.*
-import dev.ja.marketplace.data.util.SimpleTrialTracker
-import dev.ja.marketplace.data.util.TrialTracker
+import dev.ja.marketplace.data.trackers.*
 import dev.ja.marketplace.util.isZero
 import java.util.*
 
-class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleDataTable("Overview", "overview", "table-striped tables-row"),
+class OverviewTable : SimpleDataTable("Overview", "overview", "table-striped tables-row"),
     MarketplaceDataSink {
 
     private enum class CustomerSegment {
@@ -28,16 +27,16 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
 
         companion object {
             fun of(licenseInfo: LicenseInfo): CustomerSegment {
-                val isFreeLicense = licenseInfo.saleLineItem.isFreeLicense
+                val isPaidLicense = licenseInfo.isPaidLicense
                 return when {
-                    isFreeLicense -> when (licenseInfo.sale.licensePeriod) {
-                        LicensePeriod.Annual -> AnnualFree
-                        LicensePeriod.Monthly -> MonthlyFree
+                    isPaidLicense -> when (licenseInfo.sale.licensePeriod) {
+                        LicensePeriod.Annual -> AnnualPaying
+                        LicensePeriod.Monthly -> MonthlyPaying
                     }
 
                     else -> when (licenseInfo.sale.licensePeriod) {
-                        LicensePeriod.Annual -> AnnualPaying
-                        LicensePeriod.Monthly -> MonthlyPaying
+                        LicensePeriod.Annual -> AnnualFree
+                        LicensePeriod.Monthly -> MonthlyFree
                     }
                 }
             }
@@ -48,11 +47,14 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
         val year: Int,
         val month: Int,
         val customers: CustomerTracker<CustomerSegment>,
+        val licenses: LicenseTracker<CustomerSegment>,
         val amounts: PaymentAmountTracker,
         val churnCustomersAnnual: ChurnProcessor<CustomerId, CustomerInfo>,
         val churnLicensesAnnual: ChurnProcessor<LicenseId, LicenseInfo>,
         val churnCustomersMonthly: ChurnProcessor<CustomerId, CustomerInfo>,
         val churnLicensesMonthly: ChurnProcessor<LicenseId, LicenseInfo>,
+        val mrrTracker: RecurringRevenueTracker,
+        val arrTracker: RecurringRevenueTracker,
         val downloads: Long,
         val trials: TrialTracker,
     ) {
@@ -84,25 +86,39 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
 
     private val years = TreeMap<Int, YearData>(Comparator.reverseOrder())
 
-    private val columnYearMonth = DataTableColumn("month", null)
+    private val columnYearMonth = DataTableColumn("month", null, "month")
     private val columnAmountTotalUSD = DataTableColumn("sales", "Total Sales", "num")
     private val columnAmountFeesUSD = DataTableColumn("sales", "Fees", "num")
-    private val columnAmountPaidUSD = DataTableColumn("sales", "Paid", "num")
+    private val columnAmountPaidUSD = DataTableColumn("sales", "Invoice", "num")
     private val columnActiveCustomers = DataTableColumn(
         "customer-count", "Cust.", "num", tooltip = "Customers at the end of month"
     )
     private val columnActiveCustomersPaying = DataTableColumn(
-        "customer-count-paying", "Paying Cust.", "num", tooltip = "Paying customers at the end of month"
+        "customer-count-paying", "Paying", "num", tooltip = "Paying customers at the end of month"
     )
-    private val columnCustomerChurnAnnual = DataTableColumn(
-        "churn-annual-paid", "Cust. churn (annual)", "num num-percentage", tooltip = "Churn of customers with annual licenses"
+    private val columnActiveLicenses = DataTableColumn(
+        "customer-licenses", "Licenses", "num", tooltip = "Licenses at the end of month"
     )
+    private val columnActiveLicensesPaying = DataTableColumn(
+        "customer-licenses-paid", "Paid", "num", tooltip = "Paid licenses at the end of month"
+    )
+    private val columnMonthlyRecurringRevenue = DataTableColumn(
+        "customer-mrr", "MRR", "num", tooltip = "Average monthly recurring revenue (MRR)"
+    )
+    private val columnAnnualRecurringRevenue = DataTableColumn(
+        "customer-mrr", "ARR", "num", tooltip = "Average annual recurring revenue (MRR)"
+    )
+
+    //    private val columnCustomerChurnAnnual = DataTableColumn(
+//        "churn-annual-paid", "Cust. churn (annual)", "num num-percentage", tooltip = "Churn of customers with annual licenses"
+//    )
     private val columnLicenseChurnAnnual = DataTableColumn(
         "churn-annual-paid", "Churn (annual)", "num num-percentage", tooltip = "Churn of paid annual licenses"
     )
-    private val columnCustomerChurnMonthly = DataTableColumn(
-        "churn-monthly-paid", "Cust. churn (monthly)", "num num-percentage", tooltip = "Churn of customers with paid monthly licenses"
-    )
+
+    //    private val columnCustomerChurnMonthly = DataTableColumn(
+//        "churn-monthly-paid", "Cust. churn (monthly)", "num num-percentage", tooltip = "Churn of customers with paid monthly licenses"
+//    )
     private val columnLicenseChurnMonthly = DataTableColumn(
         "churn-monthly-paid", "Churn (monthly)", "num num-percentage", tooltip = "Churn of paid monthly licenses"
     )
@@ -113,20 +129,24 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
         "trials", "Trials", "num", tooltip = "Number of new trials at the end of the month"
     )
     private val columnTrialsConverted = DataTableColumn(
-        "trials-converted", "Trials Conv.", "num", tooltip = "Percentage of converted trials of the month"
+        "trials-converted", "Conv.", "num", tooltip = "Percentage of converted trials of the month"
     )
 
     override val columns: List<DataTableColumn> = listOfNotNull(
         columnYearMonth,
         columnAmountTotalUSD,
-        columnAmountFeesUSD,
+        //columnAmountFeesUSD,
         columnAmountPaidUSD,
-        columnActiveCustomers,
-        columnActiveCustomersPaying,
+        //columnActiveCustomers,
+        //columnActiveCustomersPaying,
+        columnActiveLicenses,
+        columnActiveLicensesPaying,
+        columnMonthlyRecurringRevenue,
+        columnAnnualRecurringRevenue,
         columnLicenseChurnAnnual,
         columnLicenseChurnMonthly,
-        columnCustomerChurnAnnual.takeIf { showCustomerChurn },
-        columnCustomerChurnMonthly.takeIf { showCustomerChurn },
+//        columnCustomerChurnAnnual.takeIf { showCustomerChurn },
+//        columnCustomerChurnMonthly.takeIf { showCustomerChurn },
         columnDownloads,
         columnTrials,
         columnTrialsConverted,
@@ -156,11 +176,14 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
                     year,
                     month,
                     CustomerTracker(activeCustomerRange),
+                    LicenseTracker(activeCustomerRange),
                     PaymentAmountTracker(currentMonth),
                     createCustomerChurnProcessor(currentMonth),
                     createLicenseChurnProcessor(currentMonth),
                     createCustomerChurnProcessor(currentMonth),
                     createLicenseChurnProcessor(currentMonth),
+                    createMonthlyRecurringRevenueTracker(currentMonth, data.marketplacePluginInfo),
+                    createAnnualRecurringRevenueTracker(currentMonth.expandStart(-1, 0, 0), data.marketplacePluginInfo),
                     downloadsMonthly
                         .firstOrNull { it.firstOfMonth.year == year && it.firstOfMonth.month == month }
                         ?.downloads
@@ -192,6 +215,14 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
         }
     }
 
+    private fun createMonthlyRecurringRevenueTracker(month: YearMonthDayRange, pluginInfo: MarketplacePluginInfo): RecurringRevenueTracker {
+        return MonthlyRecurringRevenueTracker(month, pluginInfo)
+    }
+
+    private fun createAnnualRecurringRevenueTracker(year: YearMonthDayRange, pluginInfo: MarketplacePluginInfo): RecurringRevenueTracker {
+        return AnnualRecurringRevenueTracker(year, pluginInfo)
+    }
+
     override fun process(sale: PluginSale) {
         val yearData = years[sale.date.year]!!
         yearData.trials.processSale(sale)
@@ -208,7 +239,7 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
 
         years.values.forEach { year ->
             val isPaidLicense = licenseInfo.isPaidLicense
-            val isRenewal = licenseInfo.isRenewal
+            val isRenewal = licenseInfo.isRenewalLicense
 
             year.churnCustomersAnnual.processValue(
                 customer.code,
@@ -242,6 +273,10 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
 
             year.months.values.forEach { month ->
                 month.customers.add(customerSegment, licenseInfo)
+                month.licenses.add(customerSegment, licenseInfo)
+
+                month.mrrTracker.processLicenseSale(licenseInfo)
+                month.arrTracker.processLicenseSale(licenseInfo)
 
                 month.churnCustomersAnnual.processValue(
                     customer.code,
@@ -286,6 +321,9 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
                 val rows = yearData.months.entries.map { (month, monthData) ->
                     val isCurrentMonth = now.year == year && now.month == month
 
+                    val mrrValue = monthData.mrrTracker.getResult().averageAmount.takeUnless { isCurrentMonth }
+                    val arrValue = monthData.arrTracker.getResult().averageAmount.takeUnless { isCurrentMonth }
+
                     val annualLicenseChurn = monthData.churnLicensesAnnual.getResult(LicensePeriod.Annual).takeUnless { isCurrentMonth }
                     val annualLicenseChurnRate = annualLicenseChurn?.getRenderedChurnRate(pluginId)
 
@@ -308,38 +346,72 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
                     val annualCustomersFree = monthData.customers.segmentCustomerCount(AnnualFree)
                     val annualCustomersPaying = monthData.customers.segmentCustomerCount(AnnualPaying)
                     val monthlyCustomersPaying = monthData.customers.segmentCustomerCount(MonthlyPaying)
-
                     val totalCustomers = monthData.customers.totalCustomerCount
                     val totalCustomersPaying = monthData.customers.payingCustomerCount
+
+                    val annualLicensesFree = monthData.licenses.segmentCustomerCount(AnnualFree)
+                    val annualLicensesPaying = monthData.licenses.segmentCustomerCount(AnnualPaying)
+                    val monthlyLicensesPaying = monthData.licenses.segmentCustomerCount(MonthlyPaying)
+                    val totalLicenses = monthData.licenses.totalLicenseCount
+                    val totalLicensesPaying = monthData.licenses.paidLicensesCount
+
                     val trialsMonth = monthData.trials.getResult()
                     val downloadCount = monthData.downloads
+
+                    val paidAnnual = monthData.licenses.getSegment(AnnualPaying)
+                    val paidAnnualIndividuals = paidAnnual.filter { it.sale.customer.type == CustomerType.Personal }
+                    val paidAnnualOrgs = paidAnnual.filter { it.sale.customer.type == CustomerType.Organization }
+
+                    val paidMonthly = monthData.licenses.getSegment(MonthlyPaying)
+                    val paidMonthlyIndividuals = paidMonthly.filter { it.sale.customer.type == CustomerType.Personal }
+                    val paidMonthlyOrgs = paidMonthly.filter { it.sale.customer.type == CustomerType.Organization }
+
+                    val paidLicensesTooltip = """
+                        $annualLicensesPaying annual
+                        $monthlyLicensesPaying monthly
+                        
+                        Annual / Individuals:
+                        ${paidAnnualIndividuals.continuityTooltip()}
+                        Annual / Organizations:
+                        ${paidAnnualOrgs.continuityTooltip()}
+
+                        Monthly / Individuals:
+                        ${paidMonthlyIndividuals.continuityTooltip()}
+                        Monthly / Organizations:
+                        ${paidMonthlyOrgs.continuityTooltip()}
+                    """.trimIndent()
 
                     SimpleDateTableRow(
                         values = mapOf(
                             columnYearMonth to String.format("%02d-%02d", year, month),
                             columnActiveCustomers to totalCustomers.toBigInteger(),
                             columnActiveCustomersPaying to totalCustomersPaying.toBigInteger(),
+                            columnActiveLicenses to totalLicenses.toBigInteger(),
+                            columnActiveLicensesPaying to totalLicensesPaying.toBigInteger(),
+                            columnMonthlyRecurringRevenue to (mrrValue?.withCurrency(Currency.USD) ?: "—"),
+                            columnAnnualRecurringRevenue to (arrValue?.withCurrency(Currency.USD) ?: "—"),
                             columnAmountTotalUSD to monthData.amounts.totalAmountUSD.withCurrency(Currency.USD),
                             columnAmountFeesUSD to monthData.amounts.feesAmountUSD.withCurrency(Currency.USD),
                             columnAmountPaidUSD to monthData.amounts.paidAmountUSD.withCurrency(Currency.USD),
-                            columnLicenseChurnAnnual to annualLicenseChurnRate,
-                            columnLicenseChurnMonthly to monthlyLicenseChurnRate,
-                            columnCustomerChurnMonthly to monthlyCustomerChurnRate,
-                            columnCustomerChurnAnnual to annualCustomerChurnRate,
+                            columnLicenseChurnAnnual to (annualLicenseChurnRate ?: "—"),
+                            columnLicenseChurnMonthly to (monthlyLicenseChurnRate ?: "—"),
                             columnDownloads to (downloadCount.takeIf { it > 0 }?.toBigInteger() ?: "—"),
                             columnTrials to (trialsMonth.totalTrials.takeIf { it > 0 }?.toBigInteger() ?: "—"),
                             columnTrialsConverted to trialsMonth.convertedTrialsPercentage,
                         ),
                         tooltips = mapOf(
+                            columnActiveLicenses to "$annualLicensesPaying annual (paying)" +
+                                    "\n$annualLicensesFree annual (free)" +
+                                    "\n$monthlyLicensesPaying monthly (paying)",
+                            columnActiveLicensesPaying to paidLicensesTooltip,
+                            columnLicenseChurnAnnual to annualLicenseChurn?.churnRateTooltip,
+                            columnLicenseChurnMonthly to monthlyLicenseChurn?.churnRateTooltip,
+                            columnTrialsConverted to trialsMonth.tooltipConverted,
+                            // fixme drop
                             columnActiveCustomers to "$annualCustomersPaying annual (paying)" +
                                     "\n$annualCustomersFree annual (free)" +
                                     "\n$monthlyCustomersPaying monthly (paying)",
                             columnActiveCustomersPaying to "$annualCustomersPaying annual\n$monthlyCustomersPaying monthly",
-                            columnLicenseChurnAnnual to annualLicenseChurn?.churnRateTooltip,
-                            columnLicenseChurnMonthly to monthlyLicenseChurn?.churnRateTooltip,
-                            columnCustomerChurnAnnual to annualCustomerChurn?.churnRateTooltip,
-                            columnCustomerChurnMonthly to monthlyCustomerChurn?.churnRateTooltip,
-                            columnTrialsConverted to trialsMonth.tooltipConverted,
                         ),
                         cssClass = cssClass
                     )
@@ -361,8 +433,6 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
                             values = mapOf(
                                 columnLicenseChurnAnnual to yearLicenseChurnAnnual.getRenderedChurnRate(pluginId),
                                 columnLicenseChurnMonthly to yearLicenseChurnMonthly.getRenderedChurnRate(pluginId),
-                                columnCustomerChurnAnnual to yearCustomerChurnAnnual.getRenderedChurnRate(pluginId),
-                                columnCustomerChurnMonthly to yearCustomerChurnMonthly.getRenderedChurnRate(pluginId),
                                 columnDownloads to yearData.months.values.sumOf { it.downloads }.toBigInteger(),
                                 columnTrials to trialsYear.totalTrials.toBigInteger(),
                                 columnTrialsConverted to trialsYear.convertedTrialsPercentage,
@@ -370,14 +440,22 @@ class OverviewTable(private val showCustomerChurn: Boolean = false) : SimpleData
                             tooltips = mapOf(
                                 columnLicenseChurnAnnual to yearLicenseChurnAnnual.churnRateTooltip,
                                 columnLicenseChurnMonthly to yearLicenseChurnMonthly.churnRateTooltip,
-                                columnCustomerChurnAnnual to yearCustomerChurnAnnual.churnRateTooltip,
-                                columnCustomerChurnMonthly to yearCustomerChurnMonthly.churnRateTooltip,
                                 columnTrialsConverted to trialsYear.tooltipConverted,
                             )
                         )
                     )
                 )
             }
+    }
+
+    private fun List<LicenseInfo>.continuityTooltip(): String {
+        val groups = this.groupBy { it.saleLineItem.discountDescriptions.firstOrNull { it.isContinuityDiscount }?.percent ?: 0.0 }
+        return buildString {
+            for ((percent, licenses) in groups) {
+                append("$percent: ${licenses.size}")
+                append("\n")
+            }
+        }
     }
 
     private fun createCustomerChurnProcessor(timeRange: YearMonthDayRange): ChurnProcessor<CustomerId, CustomerInfo> {

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/topCountries/TopCountriesTable.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/topCountries/TopCountriesTable.kt
@@ -8,8 +8,8 @@ package dev.ja.marketplace.data.topCountries
 import dev.ja.marketplace.client.*
 import dev.ja.marketplace.client.Currency
 import dev.ja.marketplace.data.*
-import dev.ja.marketplace.data.util.SimpleTrialTracker
-import dev.ja.marketplace.data.util.TrialTracker
+import dev.ja.marketplace.data.trackers.SimpleTrialTracker
+import dev.ja.marketplace.data.trackers.TrialTracker
 import java.util.*
 
 private data class CountryData(

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/topTrialCountries/TopTrialCountriesTable.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/topTrialCountries/TopTrialCountriesTable.kt
@@ -8,8 +8,8 @@ package dev.ja.marketplace.data.topTrialCountries
 import dev.ja.marketplace.client.Country
 import dev.ja.marketplace.client.PluginSale
 import dev.ja.marketplace.data.*
-import dev.ja.marketplace.data.util.SimpleTrialTracker
-import dev.ja.marketplace.data.util.TrialTracker
+import dev.ja.marketplace.data.trackers.SimpleTrialTracker
+import dev.ja.marketplace.data.trackers.TrialTracker
 import java.math.BigDecimal
 import java.util.*
 

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/ContinuityDiscountTracker.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/ContinuityDiscountTracker.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Joachim Ansorg.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package dev.ja.marketplace.data.trackers
+
+import dev.ja.marketplace.client.YearMonthDay
+import dev.ja.marketplace.data.LicenseId
+import dev.ja.marketplace.data.LicenseInfo
+import java.util.*
+
+/**
+ * Tracks the current continuity discount of licenses and can provide the continuity discount
+ */
+class ContinuityDiscountTracker {
+    private val newSalesValidity = mutableMapOf<LicenseId, TreeSet<LicenseInfo>>()
+
+    fun process(license: LicenseInfo) {
+        if (license.isNewLicense) {
+            val sales = newSalesValidity.computeIfAbsent(license.id) { TreeSet() }
+            sales += license
+        }
+    }
+
+    fun nextContinuityFactor(licenseId: LicenseId, atDate: YearMonthDay): Double {
+        val latestNewSale = newSalesValidity[licenseId]?.lastOrNull { it.validity.end < atDate } ?: return 1.0
+        val months = latestNewSale.validity.start.monthsUntil(atDate)
+        return when {
+            months >= 24 -> 0.6 // 40% in the 3rd year or later
+            months >= 12 -> 0.8 // 20% in the 2nd year or later
+            else -> 1.0 // 0%
+        }
+    }
+}

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/CustomerTracker.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/CustomerTracker.kt
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2023 Joachim Ansorg.
+ * Copyright (c) 2023-2024 Joachim Ansorg.
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-package dev.ja.marketplace.data.overview
+package dev.ja.marketplace.data.trackers
 
 import dev.ja.marketplace.client.CustomerInfo
 import dev.ja.marketplace.client.YearMonthDayRange
@@ -40,10 +40,10 @@ class CustomerTracker<T>(private val dateRange: YearMonthDayRange) {
 
             customers += customer
 
-            if (licenseInfo.saleLineItem.isFreeLicense) {
-                customersFree += customer
-            } else {
+            if (licenseInfo.isPaidLicense) {
                 customersPaying += customer
+            } else {
+                customersFree += customer
             }
 
             segmentedCustomers.computeIfAbsent(segment) { mutableSetOf() } += customer

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/LicenseTracker.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/LicenseTracker.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023-2024 Joachim Ansorg.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package dev.ja.marketplace.data.trackers
+
+import dev.ja.marketplace.client.YearMonthDayRange
+import dev.ja.marketplace.data.LicenseInfo
+
+class LicenseTracker<T>(private val dateRange: YearMonthDayRange) {
+    private val segmentedLicenses = mutableMapOf<T, MutableSet<LicenseInfo>>()
+    private val licenses = mutableSetOf<LicenseInfo>()
+    private val licensesFree = mutableSetOf<LicenseInfo>()
+    private val licensesPaying = mutableSetOf<LicenseInfo>()
+
+    val totalLicenseCount: Int
+        get() {
+            return licenses.size
+        }
+
+    val freeLicensesCount: Int
+        get() {
+            return licensesFree.size
+        }
+
+    val paidLicensesCount: Int
+        get() {
+            return licensesPaying.size
+        }
+
+    fun segmentCustomerCount(segment: T): Int {
+        return segmentedLicenses[segment]?.size ?: 0
+    }
+
+    fun getSegment(segment: T): Collection<LicenseInfo> {
+        return segmentedLicenses[segment] ?: emptyList()
+    }
+
+    fun add(segment: T, licenseInfo: LicenseInfo) {
+        if (dateRange.end in licenseInfo.validity) {
+            licenses += licenseInfo
+
+            if (licenseInfo.isPaidLicense) {
+                licensesPaying += licenseInfo
+            } else {
+                licensesFree += licenseInfo
+            }
+
+            segmentedLicenses.computeIfAbsent(segment) { mutableSetOf() } += licenseInfo
+        }
+    }
+}

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/RecurringRevenueTracker.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/RecurringRevenueTracker.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2024 Joachim Ansorg.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package dev.ja.marketplace.data.trackers
+
+import dev.ja.marketplace.client.*
+import dev.ja.marketplace.data.LicenseId
+import dev.ja.marketplace.data.LicenseInfo
+import java.math.BigDecimal
+import java.util.*
+
+/**
+ * Tracks recurring revenue for a given time period, e.g. one month or one year.
+ */
+abstract class RecurringRevenueTracker(
+    protected val dateRange: YearMonthDayRange,
+    protected val pluginInfo: MarketplacePluginInfo
+) {
+    protected val latestSales = TreeMap<LicenseId, LicenseInfo>()
+    protected val continuityTracker = ContinuityDiscountTracker()
+
+    protected abstract fun dateRangeSubscriptionPrice(license: LicenseInfo): Amount
+
+    /**
+     * @return The expected continuity discount for the next month or year.
+     */
+    protected abstract fun nextContinuityDiscountFactor(license: LicenseInfo): Double
+
+    fun processLicenseSale(licenseInfo: LicenseInfo) {
+        if (!licenseInfo.isPaidLicense) {
+            return
+        }
+
+        // track all, not just those in the filtered revenue range
+        continuityTracker.process(licenseInfo)
+
+        if (isValid(licenseInfo)) {
+            // only keep the latest valid license sale
+            latestSales.merge(licenseInfo.id, licenseInfo) { old, new ->
+                when {
+                    new.validity > old.validity -> new
+                    else -> old
+                }
+            }
+        }
+    }
+
+    fun getResult(): RecurringRevenue {
+        var result = Amount(0)
+
+        for ((_, license) in latestSales) {
+            val currentContinuity = license.saleLineItem.discountDescriptions.firstOrNull { it.isContinuityDiscount }
+
+            val rangeBasePrice = dateRangeSubscriptionPrice(license)
+            val continuityFactor = nextContinuityDiscountFactor(license)
+            val discounts = otherDiscountsFactor(license) * continuityFactor
+            result += Marketplace.paidAmount(license.validity.end, rangeBasePrice * discounts.toBigDecimal())
+        }
+
+        return RecurringRevenue(dateRange, result)
+    }
+
+    private fun isValid(license: LicenseInfo): Boolean {
+        return dateRange.start in license.validity || dateRange.end in license.validity
+    }
+
+    private fun otherDiscountsFactor(licenseInfo: LicenseInfo): Double {
+        val otherPercent = licenseInfo.saleLineItem.discountDescriptions
+            .filterNot(PluginSaleItemDiscount::isContinuityDiscount)
+            .mapNotNull { it.percent }
+
+        var factor = 1.0
+        for (percent in otherPercent) {
+            factor *= 1.0 - percent / 100.0
+        }
+        return factor
+    }
+}
+
+class MonthlyRecurringRevenueTracker(
+    month: YearMonthDayRange,
+    pluginInfo: MarketplacePluginInfo,
+) : RecurringRevenueTracker(month, pluginInfo) {
+
+    // annual subscription is 12 * monthly subscription price, calculated for a single month
+    private val annualToMonthlyFactor = BigDecimal.valueOf(10.0 / 12.0)
+
+    override fun nextContinuityDiscountFactor(license: LicenseInfo): Double {
+        return continuityTracker.nextContinuityFactor(license.id, license.validity.start.add(0, 1, 0))
+    }
+
+    override fun dateRangeSubscriptionPrice(license: LicenseInfo): Amount {
+        val basePrice = when (license.sale.customer.type) {
+            CustomerType.Personal -> pluginInfo.individualPrice
+            CustomerType.Organization -> pluginInfo.businessPrice
+        }
+
+        return when (license.sale.licensePeriod) {
+            LicensePeriod.Monthly -> basePrice
+            LicensePeriod.Annual -> basePrice * annualToMonthlyFactor
+        }
+    }
+}
+
+class AnnualRecurringRevenueTracker(
+    month: YearMonthDayRange,
+    pluginInfo: MarketplacePluginInfo,
+) : RecurringRevenueTracker(month, pluginInfo) {
+    // annual subscription price is 10 * monthly subscription price
+    private val annualFactor = BigDecimal.valueOf(10)
+
+    // monthly subscription is paid 12 times per year
+    private val monthlyToAnnualFactor = BigDecimal.valueOf(12)
+
+    override fun nextContinuityDiscountFactor(license: LicenseInfo): Double {
+        return continuityTracker.nextContinuityFactor(license.id, license.validity.start.add(1, 0, 0))
+    }
+
+    override fun dateRangeSubscriptionPrice(license: LicenseInfo): Amount {
+        val basePrice = when (license.sale.customer.type) {
+            CustomerType.Personal -> pluginInfo.individualPrice
+            CustomerType.Organization -> pluginInfo.businessPrice
+        }
+
+        return when (license.sale.licensePeriod) {
+            LicensePeriod.Monthly -> basePrice * monthlyToAnnualFactor
+            LicensePeriod.Annual -> basePrice * annualFactor
+        }
+    }
+}
+
+data class RecurringRevenue(
+    val dateRange: YearMonthDayRange,
+    val averageAmount: Amount
+)

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/TrialTracker.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/TrialTracker.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-package dev.ja.marketplace.data.util
+package dev.ja.marketplace.data.trackers
 
 import dev.ja.marketplace.client.CustomerId
 import dev.ja.marketplace.client.PluginSale

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/yearSummary/YearlySummaryTable.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/yearSummary/YearlySummaryTable.kt
@@ -8,8 +8,8 @@ package dev.ja.marketplace.data.yearSummary
 import dev.ja.marketplace.client.*
 import dev.ja.marketplace.client.Currency
 import dev.ja.marketplace.data.*
-import dev.ja.marketplace.data.util.SimpleTrialTracker
-import dev.ja.marketplace.data.util.TrialTracker
+import dev.ja.marketplace.data.trackers.SimpleTrialTracker
+import dev.ja.marketplace.data.trackers.TrialTracker
 import dev.ja.marketplace.util.isZero
 import java.util.*
 

--- a/marketplace-data/src/test/kotlin/dev/ja/SalesGenerator.kt
+++ b/marketplace-data/src/test/kotlin/dev/ja/SalesGenerator.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Joachim Ansorg.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package dev.ja
+
+import dev.ja.marketplace.TestCustomers
+import dev.ja.marketplace.client.*
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.random.Random
+
+object SalesGenerator {
+    fun createSale(
+        type: LicensePeriod = LicensePeriod.Annual,
+        saleDate: YearMonthDay? = null,
+        validity: YearMonthDayRange? = null,
+        customer: CustomerInfo? = null,
+        amount: Amount? = null,
+        currency: Currency = Currency.USD,
+        saleType: PluginSaleItemType = PluginSaleItemType.New,
+    ): PluginSale {
+        val start = saleDate ?: nextDate()
+        val usedValidity = validity
+            ?: if (type == LicensePeriod.Annual) start.rangeTo(start.add(1, 0, -1)) else start.rangeTo(start.add(0, 1, -1))
+
+        val usedAmount = amount ?: randomAmount()
+        return PluginSale(
+            nextRef(),
+            start,
+            usedAmount,
+            usedAmount,
+            currency,
+            type,
+            customer ?: TestCustomers.PersonDummy,
+            null,
+            listOf(PluginSaleItem(saleType, listOf(nextLicenseId()), usedValidity, usedAmount, usedAmount, emptyList()))
+        )
+    }
+
+    private val refId = AtomicInteger()
+
+    private fun nextRef(): String {
+        return "sale-${refId.getAndIncrement()}"
+    }
+
+    private val licenseId = AtomicInteger()
+
+    private fun nextLicenseId(): String {
+        return "license-${licenseId.getAndIncrement()}"
+    }
+
+    private var date = YearMonthDay(2021, 1, 1)
+    private fun nextDate(): YearMonthDay {
+        date = date.add(0, 1, 0)
+        return date
+    }
+
+    private fun randomAmount(): Amount {
+        return Random.nextInt(50).toBigDecimal()
+    }
+}

--- a/marketplace-data/src/test/kotlin/dev/ja/marketplace/TestCustomers.kt
+++ b/marketplace-data/src/test/kotlin/dev/ja/marketplace/TestCustomers.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2024 Joachim Ansorg.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package dev.ja.marketplace
+
+import dev.ja.marketplace.client.CustomerInfo
+import dev.ja.marketplace.client.CustomerType
+
+object TestCustomers {
+    val PersonDummy = CustomerInfo(100, "DE", CustomerType.Personal, "Dummy Person")
+    val OrganizationDummy = CustomerInfo(200, "DE", CustomerType.Organization, "Dummy Person")
+}

--- a/marketplace-data/src/test/kotlin/dev/ja/marketplace/data/trackers/ContinuityDiscountTrackerTest.kt
+++ b/marketplace-data/src/test/kotlin/dev/ja/marketplace/data/trackers/ContinuityDiscountTrackerTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 Joachim Ansorg.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package dev.ja.marketplace.data.trackers
+
+import dev.ja.SalesGenerator
+import dev.ja.marketplace.client.LicensePeriod
+import dev.ja.marketplace.client.YearMonthDay
+import dev.ja.marketplace.client.YearMonthDayRange
+import dev.ja.marketplace.data.LicenseInfo
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ContinuityDiscountTrackerTest {
+    @Test
+    fun basics() {
+        val tracker = ContinuityDiscountTracker()
+        assertEquals(1.0, tracker.nextContinuityFactor("any", YearMonthDay.now()))
+
+        val validity = YearMonthDayRange(YearMonthDay(2024, 6, 1), YearMonthDay(2024, 6, 30))
+
+        val sale = SalesGenerator.createSale(validity = validity, type = LicensePeriod.Monthly)
+        val license = LicenseInfo.create(listOf(sale)).first()
+        tracker.process(license)
+
+        // 2nd and 3rd year
+        assertEquals(1.0, tracker.nextContinuityFactor(license.id, validity.start))
+        assertEquals(1.0, tracker.nextContinuityFactor(license.id, validity.end))
+        assertEquals(1.0, tracker.nextContinuityFactor(license.id, validity.end.add(0, 11, 0)))
+
+        assertEquals(0.8, tracker.nextContinuityFactor(license.id, validity.end.add(0, 12, 0)))
+        assertEquals(0.8, tracker.nextContinuityFactor(license.id, validity.end.add(0, 13, 0)))
+        assertEquals(0.8, tracker.nextContinuityFactor(license.id, validity.end.add(0, 23, 0)))
+
+        assertEquals(0.6, tracker.nextContinuityFactor(license.id, validity.end.add(0, 24, 0)))
+        assertEquals(0.6, tracker.nextContinuityFactor(license.id, validity.end.add(0, 25, 0)))
+    }
+}

--- a/src/main/kotlin/dev/ja/marketplace/MarketplaceStatsServer.kt
+++ b/src/main/kotlin/dev/ja/marketplace/MarketplaceStatsServer.kt
@@ -401,7 +401,7 @@ class MarketplaceStatsServer(
                 it,
                 it.validity,
                 it.sale.licensePeriod == period && it.isPaidLicense,
-                it.isRenewal
+                it.isRenewalLicense
             )
         }
 

--- a/src/main/kotlin/dev/ja/marketplace/PluginDataLoader.kt
+++ b/src/main/kotlin/dev/ja/marketplace/PluginDataLoader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Joachim Ansorg.
+ * Copyright (c) 2023-2024 Joachim Ansorg.
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
@@ -17,6 +17,7 @@ class PluginDataLoader(val plugin: PluginInfoSummary, val client: MarketplaceCli
     suspend fun load(): PluginData {
         return coroutineScope {
             val pluginInfo = async { client.pluginInfo(plugin.id) }
+            val marketplacePluginInfo = async { client.marketplacePluginInfo(plugin.id) }
             val pluginRating = async { client.pluginRating(plugin.id) }
             val downloadsTotal = async { client.downloadsTotal(plugin.id) }
             val downloadsMonthly = async { client.downloadsMonthly(plugin.id, Downloads) }
@@ -40,6 +41,7 @@ class PluginDataLoader(val plugin: PluginInfoSummary, val client: MarketplaceCli
                 plugin.id,
                 plugin,
                 pluginInfo.await(),
+                marketplacePluginInfo.await(),
                 pluginRating.await(),
                 downloadsTotal.await(),
                 downloadsMonthly.await(),


### PR DESCRIPTION
Also switch to active licenses and active paid licenses instead of customers. The number of customers is misleading if few customers purchase many licenses. The churn rate is  based on licenses already. Drops "Fee" from the monthly summary to gain space. The fee is still in the yearly summary.