### PR TITLE
Change "Converted Trials" to the number of trials converted within the configured trial duration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,9 @@ allprojects {
         // https://mvnrepository.com/artifact/org.javamoney.moneta/moneta-convert-ecb
         implementation("org.javamoney.moneta:moneta-convert-ecb:1.4.4")
 
+        // https://mvnrepository.com/artifact/com.google.guava/guava
+        implementation("com.google.guava:guava:33.2.1-jre")
+
         // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api
         testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.3")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.3")

--- a/marketplace-client/src/main/kotlin/dev/ja/marketplace/client/Marketplace.kt
+++ b/marketplace-client/src/main/kotlin/dev/ja/marketplace/client/Marketplace.kt
@@ -17,6 +17,7 @@ object Marketplace {
     private val regularFeeFactor = BigDecimal("0.15")
 
     val Birthday = YearMonthDay(2019, 6, 25)
+    const val MAX_TRIAL_DAYS_DEFAULT: Int = 30
 
     fun feeAmount(date: YearMonthDay, amount: MonetaryAmount): MonetaryAmount {
         return when {

--- a/marketplace-client/src/main/kotlin/dev/ja/marketplace/client/types.kt
+++ b/marketplace-client/src/main/kotlin/dev/ja/marketplace/client/types.kt
@@ -27,6 +27,8 @@ typealias LicenseId = String
 typealias JetBrainsProductId = String
 typealias PluginModuleName = String
 
+typealias TrialId = String
+
 interface WithAmounts {
     val amount: MonetaryAmount
     val amountUSD: MonetaryAmount
@@ -474,7 +476,7 @@ data class PluginSaleItemDiscount(
 @Serializable
 data class PluginTrial(
     @SerialName("ref")
-    val referenceId: String,
+    val referenceId: TrialId,
     @SerialName("date")
     val date: YearMonthDay,
     @SerialName("customer")

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/topCountries/TopCountriesTable.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/topCountries/TopCountriesTable.kt
@@ -147,7 +147,12 @@ class TopCountriesTable(
             SimpleTableSection(
                 rows,
                 footer = when {
-                    maxItems != null -> null
+                    maxItems != null -> SimpleTableSection(
+                        SimpleDateTableRow(
+                            columnCountry to "${countries.size} countries",
+                        )
+                    )
+
                     else -> SimpleTableSection(
                         SimpleDateTableRow(
                             values = mapOf(

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/TrialTracker.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/trackers/TrialTracker.kt
@@ -5,69 +5,103 @@
 
 package dev.ja.marketplace.data.trackers
 
+import com.google.common.collect.Multimaps
 import dev.ja.marketplace.client.CustomerId
 import dev.ja.marketplace.client.PluginSale
 import dev.ja.marketplace.client.PluginTrial
+import dev.ja.marketplace.client.YearMonthDayRange
 import dev.ja.marketplace.data.PercentageValue
 
 data class TrialTrackerInfo(
     val totalTrials: Int,
-    val convertedTrialsCount: Int,
     val convertedTrials: Map<PluginTrial, PluginSale>,
 ) {
+    val convertedTrialsCount: Int = convertedTrials.size
+
     val convertedTrialsPercentage: PercentageValue
         get() {
             return PercentageValue.of(convertedTrialsCount, totalTrials)
         }
 
-    val tooltipConverted: String
-        get() {
-            return "$convertedTrialsCount trials of $totalTrials converted"
+    fun getTooltipConverted(maxTrialDays: Int? = null): String {
+        return when {
+            maxTrialDays == null -> "$convertedTrialsCount trials of $totalTrials converted ($convertedTrialsPercentage)"
+            else -> "$convertedTrialsCount trials of $totalTrials converted within $maxTrialDays days ($convertedTrialsPercentage)"
         }
+    }
 }
 
 /**
  * Tracks conversion of trials into subscriptions.
  */
 interface TrialTracker {
-    fun registerTrial(trial: PluginTrial)
+    fun init(allTrials: Iterable<PluginTrial>)
 
     fun processSale(saleInfo: PluginSale)
 
-    fun getResult(): TrialTrackerInfo
+    fun getResult(
+        trialStartDateRange: YearMonthDayRange,
+        isValidConversion: (PluginTrial, PluginSale) -> Boolean = { _, _ -> true }
+    ): TrialTrackerInfo
 }
 
-class SimpleTrialTracker(val trialFilter: (PluginTrial) -> Boolean = { true }) : TrialTracker {
-    private val allTrials = mutableSetOf<PluginTrial>()
-    private val trialsByCustomer = mutableMapOf<CustomerId, PluginTrial>()
-    private val convertedTrials = mutableMapOf<CustomerId, MutableList<PluginSale>>()
+fun TrialTracker.getResultByTrialDuration(trialStartDateRange: YearMonthDayRange, maxTrialDays: Int): TrialTrackerInfo {
+    return getResult(trialStartDateRange) { trial, sale ->
+        trial.date.daysUntil(sale.date) <= maxTrialDays
+    }
+}
 
-    override fun registerTrial(trial: PluginTrial) {
-        if (trialFilter(trial)) {
-            allTrials += trial
+fun TrialTracker.getResultBySaleDate(trialStartDateRange: YearMonthDayRange, saleDateRange: YearMonthDayRange): TrialTrackerInfo {
+    return getResult(trialStartDateRange) { _, sale ->
+        sale.date in saleDateRange
+    }
+}
 
-            // only record the latest trials
-            val customerId = trial.customer.code
-            if (customerId !in this.trialsByCustomer || this.trialsByCustomer[customerId]!!.date < trial.date) {
-                this.trialsByCustomer[customerId] = trial
-            }
+class SimpleTrialTracker : TrialTracker {
+    private data class TrialRecord(val trial: PluginTrial, var nextSale: PluginSale? = null)
+
+    private val trialRecords = mutableListOf<TrialRecord>()
+    private val trialsByCustomerId = Multimaps.newListMultimap<CustomerId, TrialRecord>(mutableMapOf(), ::ArrayList)
+
+    override fun init(allTrials: Iterable<PluginTrial>) {
+        for (trial in allTrials) {
+            // the same record must be shared in the maps
+            val trialRecord = TrialRecord(trial)
+            trialRecords += trialRecord
+            trialsByCustomerId.put(trial.customer.code, trialRecord)
         }
     }
 
     override fun processSale(saleInfo: PluginSale) {
-        val customerId = saleInfo.customer.code
-        val trial = trialsByCustomer[customerId]
-        if (trial != null && trial.date <= saleInfo.date) {
-            convertedTrials.getOrPut(customerId, ::ArrayList) += saleInfo
+        val sortedTrials = trialsByCustomerId[saleInfo.customer.code]//.sortedBy { it.trial.date }
+        if (sortedTrials.isNotEmpty()) {
+            val newestTrialForSale = sortedTrials.lastOrNull { it.trial.date <= saleInfo.date }
+            if (newestTrialForSale != null) {
+                val existingSaleDate = newestTrialForSale.nextSale?.date
+                if (existingSaleDate == null || existingSaleDate > saleInfo.date) {
+                    newestTrialForSale.nextSale = saleInfo
+                }
+            }
         }
     }
 
-    override fun getResult(): TrialTrackerInfo {
-        val convertedTrialsList = convertedTrials.mapKeys { trialsByCustomer[it.key]!! }
-        return TrialTrackerInfo(
-            allTrials.size,
-            convertedTrials.size,
-            convertedTrialsList.mapValues { it.value.minBy(PluginSale::date) }
-        )
+    override fun getResult(
+        trialStartDateRange: YearMonthDayRange,
+        isValidConversion: (PluginTrial, PluginSale) -> Boolean,
+    ): TrialTrackerInfo {
+        var validTrialsCount = 0
+        val convertedTrials = mutableMapOf<PluginTrial, PluginSale>()
+
+        // iterating to avoid expensive and unnecessary filtering and flattening of the multimap
+        for ((trial, sale) in trialRecords) {
+            if (trial.date in trialStartDateRange) {
+                validTrialsCount++
+                if (sale != null && isValidConversion(trial, sale)) {
+                    convertedTrials[trial] = sale
+                }
+            }
+        }
+
+        return TrialTrackerInfo(validTrialsCount, convertedTrials)
     }
 }

--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/types.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/types.kt
@@ -16,6 +16,10 @@ import java.math.RoundingMode
 import javax.money.MonetaryAmount
 
 data class PercentageValue(val value: BigDecimal) {
+    override fun toString(): String {
+        return String.format("%,.2f %%", value)
+    }
+
     companion object {
         private val ONE_HUNDRED_DECIMAL = BigDecimal.valueOf(100)
 


### PR DESCRIPTION
Previously, a trial conversion was only recorded if the sale happened within the same month, which is very misleading and unreliable.