### PR TITLE
feat: show error page when requests to the JetBrains Marketplace fail

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,6 +106,7 @@ project(":") {
         implementation("io.ktor:ktor-server-netty:$ktorVersion")
         implementation("io.ktor:ktor-server-compression:$ktorVersion")
         implementation("io.ktor:ktor-server-jte:$ktorVersion")
+        implementation("io.ktor:ktor-server-status-pages:$ktorVersion")
 
         // https://mvnrepository.com/artifact/gg.jte/jte
         implementation("gg.jte:jte:3.1.10")

--- a/src/main/kotlin/dev/ja/marketplace/MarketplaceStatsServer.kt
+++ b/src/main/kotlin/dev/ja/marketplace/MarketplaceStatsServer.kt
@@ -39,6 +39,7 @@ import io.ktor.server.http.content.*
 import io.ktor.server.jte.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.compression.*
+import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -160,6 +161,17 @@ class MarketplaceStatsServer(
             templateEngine = TemplateEngine.createPrecompiled(ContentType.Html).also {
                 it.prepareForRendering("main.kte")
                 it.prepareForRendering("plugins.kte")
+            }
+        }
+        install(StatusPages) {
+            exception<Exception> { call, cause ->
+                call.respond(
+                    JteContent(
+                        "error_exception.kte", mapOf(
+                            "exception" to cause,
+                        )
+                    )
+                )
             }
         }
 

--- a/src/main/resources/templates/error_exception.kte
+++ b/src/main/resources/templates/error_exception.kte
@@ -1,0 +1,25 @@
+@param exception: Exception
+
+<html lang="en">
+<head>
+    <title>Request Error</title>
+    <link rel="stylesheet" type="text/css" href="/styles/main.css"/>
+    <link rel="stylesheet" type="text/css" media="print" href="/styles/main.css"/>
+</head>
+<body>
+<h1>Error</h1>
+
+<p class="desc margin-bottom">
+    An error occurred while preparing the page.
+    It could be a bug in marketplace-stats server itself or request to the JetBrains Marketplace.
+</p>
+
+<dl>
+    <dt>Stacktrace</dt>
+    <dd>
+        <pre>${exception.stackTraceToString()}</pre>
+    </dd>
+</dl>
+
+</body>
+</html>


### PR DESCRIPTION
Closes https://github.com/jansorg/marketplace-stats-kotlin/issues/36