### PR TITLE
fix: show the no vale placeholder for zero trials in the year summary table

### DIFF
--- a/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/yearSummary/YearlySummaryTable.kt
+++ b/marketplace-data/src/main/kotlin/dev/ja/marketplace/data/yearSummary/YearlySummaryTable.kt
@@ -104,7 +104,7 @@ class YearlySummaryTable : SimpleDataTable("Years", "years", "table-column-wide"
                             .filter { it.firstOfMonth.year == year }
                             .sumOf(MonthlyDownload::downloads)
                             .toBigInteger(),
-                        columnTrials to trialResultAnyDuration.totalTrials.toBigInteger(),
+                        columnTrials to (trialResultAnyDuration.totalTrials.takeIf { it >= 0 }?.toBigInteger() ?: NoValue),
                         columnTrialsConverted to trialResultAnyDuration.convertedTrialsPercentage,
                     ),
                     tooltips = mapOf(


### PR DESCRIPTION
Closes https://github.com/jansorg/marketplace-stats-kotlin/issues/82